### PR TITLE
Link: Remove box-shadow on click (active)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ $seed-button-styles: (
       default: transparent,
       hover: transparent,
       active: transparent,
-      focus: #237AB3
+      focus: transparent,
     ),
     box-shadow: (
       default: none,

--- a/scss/pack/seed-button/mixins/_generate-button-styles.scss
+++ b/scss/pack/seed-button/mixins/_generate-button-styles.scss
@@ -61,7 +61,14 @@
 
     &:active {
       @if _get($config, box-shadow, focus) and _get($config, box-shadow, active) {
-        box-shadow: _get($config, box-shadow, focus), _get($config, box-shadow, active);
+        $focus: _get($config, box-shadow, focus);
+        $active: _get($config, box-shadow, active);
+        @if ($focus == "none") or ($active == "none") {
+          box-shadow: none;
+        }
+        @else {
+          box-shadow: $focus, $active;
+        }
       }
       @else {
         @include __set-button-prop(box-shadow, $config, active);

--- a/test/modifiers.link.js
+++ b/test/modifiers.link.js
@@ -13,6 +13,12 @@ describe('seed-button: modifiers: link', () => {
       expect(o.prop('border-color')).to.equal('transparent');
     });
 
+    it('should not have box-shadow when clicked', () => {
+      expect(output.rule('.c-button--link:active').prop('box-shadow')).to.equal('none');
+      expect(output.rule('.c-button--link:focus').prop('box-shadow')).to.equal('none');
+      expect(output.rule('.c-button--link:focus:active').prop('box-shadow')).to.equal('none');
+    });
+
     it('should not have visible borders when focused + state', () => {
       expect(output.rule('.c-button--link.is-error:focus').prop('border-color')).to.equal('transparent');
       expect(output.rule('.c-button--link.is-success:focus').prop('border-color')).to.equal('transparent');


### PR DESCRIPTION
## Updates

* Normalize box-shadow for link modifier (active, focus, focus:active)
* Add tests

Resolves: https://github.com/helpscout/seed-button/issues/15