### PR TITLE
Update button colors with seed-color-scheme config

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@ var pathfinder = require('sass-pathfinder');
 
 var files = pathfinder(
   require('seed-border'),
+  require('seed-color-scheme'),
   require('seed-control'),
   require('seed-dash'),
   require('seed-publish'),
-  require('seed-states'),
   path.join(__dirname, 'scss')
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -380,39 +380,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "concat-stream": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-      "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.0.6",
-        "typedarray": "0.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "configstore": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
@@ -710,12 +677,6 @@
         "is-arrayish": "0.2.1"
       }
     },
-    "es6-promise": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
-      "integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
-      "dev": true
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -819,35 +780,6 @@
         "is-extglob": "1.0.0"
       }
     },
-    "extract-zip": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
-      "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.5.0",
-        "debug": "0.7.4",
-        "mkdirp": "0.5.0",
-        "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        }
-      }
-    },
     "extsprintf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
@@ -859,15 +791,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true,
-      "requires": {
-        "pend": "1.2.0"
-      }
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -941,17 +864,6 @@
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
-    },
-    "fs-extra": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1"
-      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1895,21 +1807,6 @@
         "globule": "1.2.0"
       }
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
-      }
-    },
     "genki": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/genki/-/genki-0.1.1.tgz",
@@ -2101,16 +1998,6 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
-    },
-    "hasha": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
-      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-      "dev": true,
-      "requires": {
-        "is-stream": "1.1.0",
-        "pinkie-promise": "2.0.1"
-      }
     },
     "hawk": {
       "version": "3.1.3",
@@ -2346,18 +2233,6 @@
         "is-extglob": "1.0.0"
       }
     },
-    "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
-    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -2383,12 +2258,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-redirect": {
@@ -2541,25 +2410,10 @@
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
-    "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
-    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "jsprim": {
@@ -2582,12 +2436,6 @@
         }
       }
     },
-    "kew": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
-      "dev": true
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -2595,15 +2443,6 @@
       "dev": true,
       "requires": {
         "is-buffer": "1.1.5"
-      }
-    },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
       }
     },
     "latest-version": {
@@ -2650,7 +2489,8 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -3022,26 +2862,6 @@
         "which": "1.2.14"
       }
     },
-    "node-qunit-phantomjs": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/node-qunit-phantomjs/-/node-qunit-phantomjs-1.5.0.tgz",
-      "integrity": "sha1-1q8tGR2JLJXoxAoTOtMIPwbVyyA=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "minimist": "1.2.0",
-        "phantomjs-prebuilt": "2.1.14",
-        "qunit-phantomjs-runner": "2.3.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
     "node-sass": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
@@ -3305,94 +3125,11 @@
         "through": "2.3.8"
       }
     },
-    "pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
-    },
     "performance-now": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true
-    },
-    "phantomjs-prebuilt": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.14.tgz",
-      "integrity": "sha1-1T0xH8+30dCN2yQBRVjxGIxRbaA=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "4.0.5",
-        "extract-zip": "1.5.0",
-        "fs-extra": "1.0.0",
-        "hasha": "2.2.0",
-        "kew": "0.7.0",
-        "progress": "1.1.8",
-        "request": "2.79.0",
-        "request-progress": "2.0.1",
-        "which": "1.2.14"
-      },
-      "dependencies": {
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.9.0",
-            "is-my-json-valid": "2.16.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        }
-      }
     },
     "pify": {
       "version": "2.3.0",
@@ -3473,12 +3210,6 @@
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
-    "progress": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-      "dev": true
-    },
     "ps-tree": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
@@ -3504,27 +3235,6 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
       "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-      "dev": true
-    },
-    "qunit-phantomjs-runner": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/qunit-phantomjs-runner/-/qunit-phantomjs-runner-2.3.0.tgz",
-      "integrity": "sha1-JwrLGXwPL8qvBmdqsKSP1aymapk=",
-      "dev": true,
-      "requires": {
-        "qunit-reporter-junit": "1.1.1"
-      }
-    },
-    "qunit-reporter-junit": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/qunit-reporter-junit/-/qunit-reporter-junit-1.1.1.tgz",
-      "integrity": "sha1-7rYiZFeJaZPnlaEZQPGK9q+lebQ=",
-      "dev": true
-    },
-    "qunitjs": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/qunitjs/-/qunitjs-2.2.1.tgz",
-      "integrity": "sha1-dsDAjJ68IyQmelkO7NLfwymC2Pg=",
       "dev": true
     },
     "randomatic": {
@@ -3738,15 +3448,6 @@
         "uuid": "3.1.0"
       }
     },
-    "request-progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
-      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-      "dev": true,
-      "requires": {
-        "throttleit": "1.0.0"
-      }
-    },
     "request-promise-core": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
@@ -3888,16 +3589,20 @@
       }
     },
     "seed-color-scheme": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/seed-color-scheme/-/seed-color-scheme-0.0.2.tgz",
-      "integrity": "sha1-QN4soNtEyzvIRGGzJmQ5ruv/w+c="
-    },
-    "seed-color-scheme-helpscout": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/seed-color-scheme-helpscout/-/seed-color-scheme-helpscout-0.0.3.tgz",
-      "integrity": "sha1-gmfvaizHVad1gaimWvJ/tKZzrEA=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/seed-color-scheme/-/seed-color-scheme-0.3.0.tgz",
+      "integrity": "sha512-yfDcq0lOzJVYC0fJ1wqtSm7SALMmIJ+CSNw/01qquK5cuoQ7AFO79YQXap3r/uE3KjBFmfb5uZMgnpMdDT/rcw==",
       "requires": {
-        "seed-color-scheme": "0.0.2"
+        "sass-pathfinder": "0.0.5",
+        "seed-config": "0.1.1"
+      }
+    },
+    "seed-config": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/seed-config/-/seed-config-0.1.1.tgz",
+      "integrity": "sha512-bHp2RBZXXhaecdGc4s9aEEe32Ob3Pa/zwHalGWoQSeyAbCD1SHC+hgRaj2gnYlW4M55zbWpJRQfErHQx4BB8pA==",
+      "requires": {
+        "sass-pathfinder": "0.0.5"
       }
     },
     "seed-control": {
@@ -3952,32 +3657,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/seed-publish/-/seed-publish-0.2.0.tgz",
       "integrity": "sha1-IAYOsyPWgIuqBDbYRPqEBJ65Rvo="
-    },
-    "seed-states": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/seed-states/-/seed-states-0.0.4.tgz",
-      "integrity": "sha1-g1lVFUKLX2kLBXYkBBqR3JMKx6E=",
-      "requires": {
-        "sass-pathfinder": "0.0.3",
-        "seed-color-scheme": "0.0.2",
-        "seed-color-scheme-helpscout": "0.0.3",
-        "seed-dash": "0.0.1"
-      },
-      "dependencies": {
-        "sass-pathfinder": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/sass-pathfinder/-/sass-pathfinder-0.0.3.tgz",
-          "integrity": "sha1-fJPBtDprqCP0IEN1kNngTITOft0=",
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "seed-dash": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/seed-dash/-/seed-dash-0.0.1.tgz",
-          "integrity": "sha1-/yHArmMzDsY6ik4+Db9Ka3ooh6I="
-        }
-      }
     },
     "semver": {
       "version": "5.3.0",
@@ -4217,12 +3896,6 @@
         "inherits": "2.0.3"
       }
     },
-    "throttleit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-      "dev": true
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -4305,12 +3978,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
       "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
-      "dev": true
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "undefsafe": {
@@ -4481,12 +4148,6 @@
       "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
       "dev": true
     },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
@@ -4543,15 +4204,6 @@
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
-      }
-    },
-    "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true,
-      "requires": {
-        "fd-slicer": "1.0.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -43,20 +43,17 @@
     "node": ">=4"
   },
   "devDependencies": {
-    "jquery": "3.2.1",
     "mkdirp": "^0.5.1",
-    "node-qunit-phantomjs": "1.5.0",
     "node-sass": "^4.5.3",
     "nodemon": "1.11.0",
-    "qunitjs": "2.2.1",
     "seed-bistro": "0.1.9"
   },
   "dependencies": {
     "sass-pathfinder": "0.0.5",
     "seed-border": "0.0.10",
+    "seed-color-scheme": "0.3.0",
     "seed-control": "0.1.0",
     "seed-dash": "0.0.2",
-    "seed-publish": "0.2.0",
-    "seed-states": "0.0.4"
+    "seed-publish": "0.2.0"
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,13 +7,7 @@ var pathfinder = require('sass-pathfinder');
 var sass = require('node-sass');
 
 var file = pkg.name;
-var includePaths = pathfinder(
-  require('seed-border'),
-  require('seed-control'),
-  require('seed-dash'),
-  require('seed-publish'),
-  require('seed-states')
-);
+var includePaths = require('../index');
 
 // Default .css compile
 sass.render({

--- a/scss/pack/seed-button/components/button/_base.scss
+++ b/scss/pack/seed-button/components/button/_base.scss
@@ -3,21 +3,23 @@
 // Dependencies
 @import "pack/seed-dash/_index";
 @import "pack/seed-publish/_index";
+@import "../../configs/color";
 @import "../../mixins/disabled-styles";
 @import "./config";
+
 
 @include export(seed-button) {
   & {
     -webkit-appearance: none;
     appearance: none;
-    background-color: _get($seed-button-color, background, default);
-    border-color: _get($seed-button-color, border, default);
+    background-color: _color(button, default, background);
+    border-color: _color(button, default, border);
     border-radius: $seed-button-border-radius;
     border-width: $seed-button-border-size;
     border-style: $seed-button-border-style;
-    box-shadow: _get($seed-button-color, box-shadow, default);
+    box-shadow: _color(button, default, box-shadow);
     box-sizing: border-box;
-    color: _get($seed-button-color, text);
+    color: _color(button, default, text);
     cursor: pointer;
     display: inline-block;
     font-size: $seed-button-font-size;
@@ -34,30 +36,31 @@
     user-select: none;
 
     &:hover {
-      background-color: _get($seed-button-color, background, hover);
-      border-color: _get($seed-button-color, border, hover);
-      color: _get($seed-button-color, text);
+      background-color: _color(button, default, background, hover);
+      border-color: _color(button, default, border, hover);
+      color: _color(button, default, text, hover);
       text-decoration: none;
     }
 
     &:active {
-      background-color: _get($seed-button-color, background, active);
-      border-color: _get($seed-button-color, border, active);
-      box-shadow: _get($seed-button-color, box-shadow, active);
+      background-color: _color(button, default, background, active);
+      border-color: _color(button, default, border, active);
+      color: _color(button, default, text, active);
     }
 
     &:focus {
-      border-color: _get($seed-button-color, border, focus);
-      box-shadow: _get($seed-button-color, box-shadow, focus);
+      border-color: _color(button, default, border, focus);
+      box-shadow: _color(button, default, box-shadow, focus);
+      color: _color(button, default, text, focus);
 
       &:active {
-        box-shadow: _get($seed-button-color, box-shadow, active);
+        box-shadow: _color(button, default, box-shadow, active);
       }
     }
 
     @include disabled-styles {
-      background-color: _get($seed-button-color, background, default);
-      border-color: _get($seed-button-color, border, default);
+      background-color: _color(button, default, background);
+      border-color: _color(button, default, border);
       text-decoration: none;
     }
   }

--- a/scss/pack/seed-button/components/button/_config.scss
+++ b/scss/pack/seed-button/components/button/_config.scss
@@ -3,15 +3,15 @@
 // Dependencies
 @import "pack/seed-border/config";
 @import "pack/seed-control/config";
-@import "pack/seed-states/_index";
+@import "../../configs/color";
 
 // Namespace
 $seed-button-namespace: "c-button" !default;
 $seed-button-primary-namespace: "primary" !default;
 $seed-button-link-namespace: "link" !default;
-$seed-button-error-namespace: "is-#{$seed-states-error-namespace}" !default;
-$seed-button-success-namespace: "is-#{$seed-states-success-namespace}" !default;
-$seed-button-warning-namespace: "is-#{$seed-states-warning-namespace}" !default;
+$seed-button-error-namespace: "is-error" !default;
+$seed-button-success-namespace: "is-success" !default;
+$seed-button-warning-namespace: "is-warning" !default;
 $seed-button-selected-namespace: is-selected !default;
 
 // Animation
@@ -33,76 +33,56 @@ $seed-button-line-height: $seed-button-height - ceil($seed-button-border-size * 
 // Padding
 $seed-button-padding: 0 1em !default;
 
-// Colors
-$seed-button-color: (
-  background: (
-    default: #fff,
-    hover: #f9f9f9,
-    active: #f4f4f4,
-    selected: #f1f1f1,
-  ),
-  border: (
-    default: #ddd,
-    hover: #ddd,
-    active: #ddd,
-    focus: #3197D6
-  ),
-  box-shadow: (
-    default: none,
-    active: 0 1px 2px rgba(black, 0.2) inset,
-    focus: none
-  ),
-  text: #2b2b2b,
-) !default;
-
 $seed-button-styles: (
   #{$seed-button-primary-namespace}: (
     _generate-states: false,
     background: (
-      default: #3197D6,
-      hover: darken(#3197D6, 4),
-      active: darken(#3197D6, 8)
+      default: _color(button, primary, background, default),
+      hover: _color(button, primary, background, hover),
+      active: _color(button, primary, background, active),
     ),
     border: (
-      default: #237AB3,
-      hover: #237AB3,
-      active: #237AB3,
-      focus: #237AB3
+      default: _color(button, primary, border, default),
+      hover: _color(button, primary, border, hover),
+      active: _color(button, primary, border, active),
+      focus: _color(button, primary, border, focus),
     ),
     box-shadow: (
-      focus: 0 0 0 1px rgba(white, 0.4) inset
+      focus: _color(button, primary, box-shadow, focus),
     ),
     text: (
-      default: #fff,
-      hover: #fff,
-      active: #fff,
-      focus: #fff,
+      default: _color(button, primary, text, default),
+      hover: _color(button, primary, text, hover),
+      active: _color(button, primary, text, active),
+      focus: _color(button, primary, text, focus),
     ),
   ),
 
   #{$seed-button-link-namespace}: (
     _generate-states: true,
     background: (
-      default: transparent,
-      hover: transparent,
-      active: transparent,
-      focus: transparent,
+      default: _color(button, link, background, default),
+      hover: _color(button, link, background, hover),
+      active: _color(button, link, background, active),
+      focus: _color(button, link, background, focus),
     ),
     border: (
-      default: transparent,
-      hover: transparent,
-      active: transparent,
-      focus: transparent,
+      default: _color(button, link, border, default),
+      hover: _color(button, link, border, hover),
+      active: _color(button, link, border, active),
+      focus: _color(button, link, border, focus),
     ),
     box-shadow: (
-      default: none,
-      hover: none,
-      active: none,
-      focus: none
+      default: _color(button, link, box-shadow, default),
+      hover: _color(button, link, box-shadow, hover),
+      active: _color(button, link, box-shadow, active),
+      focus: _color(button, link, box-shadow, focus),
     ),
     text: (
-      default: #3197D6,
-      hover: #3197D6
+      default: _color(button, link, text, default),
+      hover: _color(button, link, text, hover),
+      active: _color(button, link, text, active),
+      focus: _color(button, link, text, focus),
     ),
     text-decoration: (
       default: none,
@@ -116,14 +96,14 @@ $seed-button-styles: (
 $seed-button-color-states: (
   #{$seed-button-error-namespace}: (
     background: (
-      default: _state(error, border-color),
-      hover: darken(_state(error, border-color), 4),
-      active: darken(_state(error, border-color), 8)
+      default: _color(state, error, border-color),
+      hover: darken(_color(state, error, border-color), 4),
+      active: darken(_color(state, error, border-color), 8)
     ),
     border: (
-      default: darken(_state(error, border-color), 8),
-      hover: darken(_state(error, border-color), 8),
-      active: darken(_state(error, border-color), 8)
+      default: darken(_color(state, error, border-color), 8),
+      hover: darken(_color(state, error, border-color), 8),
+      active: darken(_color(state, error, border-color), 8)
     ),
     box-shadow: (
       focus: 0 0 0 1px rgba(white, 0.4) inset
@@ -132,14 +112,14 @@ $seed-button-color-states: (
   ),
   #{$seed-button-success-namespace}: (
     background: (
-      default: _state(success, border-color),
-      hover: darken(_state(success, border-color), 4),
-      active: darken(_state(success, border-color), 8)
+      default: _color(state, success, border-color),
+      hover: darken(_color(state, success, border-color), 4),
+      active: darken(_color(state, success, border-color), 8)
     ),
     border: (
-      default: darken(_state(success, border-color), 8),
-      hover: darken(_state(success, border-color), 8),
-      active: darken(_state(success, border-color), 8)
+      default: darken(_color(state, success, border-color), 8),
+      hover: darken(_color(state, success, border-color), 8),
+      active: darken(_color(state, success, border-color), 8)
     ),
     box-shadow: (
       focus: 0 0 0 1px rgba(white, 0.4) inset
@@ -148,14 +128,14 @@ $seed-button-color-states: (
   ),
   #{$seed-button-warning-namespace}: (
     background: (
-      default: _state(warning, border-color),
-      hover: darken(_state(warning, border-color), 4),
-      active: darken(_state(warning, border-color), 8)
+      default: _color(state, warning, border-color),
+      hover: darken(_color(state, warning, border-color), 4),
+      active: darken(_color(state, warning, border-color), 8)
     ),
     border: (
-      default: darken(_state(warning, border-color), 8),
-      hover: darken(_state(warning, border-color), 8),
-      active: darken(_state(warning, border-color), 8)
+      default: darken(_color(state, warning, border-color), 8),
+      hover: darken(_color(state, warning, border-color), 8),
+      active: darken(_color(state, warning, border-color), 8)
     ),
     box-shadow: (
       focus: 0 0 0 1px rgba(white, 0.4) inset

--- a/scss/pack/seed-button/components/button/states/_selected.scss
+++ b/scss/pack/seed-button/components/button/states/_selected.scss
@@ -8,7 +8,7 @@
 @include export(seed-button) {
   & {
     &.#{$seed-button-selected-namespace} {
-      $color: _get($seed-button-color, background, selected);
+      $color: lighten(_color(button, default, background, active), 2);
       background-color: $color;
       &:hover {
         background-color: darken($color, 2);

--- a/scss/pack/seed-button/configs/_color.scss
+++ b/scss/pack/seed-button/configs/_color.scss
@@ -1,0 +1,94 @@
+// Configs :: Color
+@import "pack/seed-color-scheme/_index";
+
+// Default
+@include _color((
+  button: (
+    default: (
+      background: (
+        default: white,
+        hover: _color(grey, 200),
+        active: _color(grey, 400),
+        selected: _color(grey, 400),
+      ),
+      border: (
+        default: _color(border, ui, dark),
+        hover: _color(border, ui, dark),
+        active: _color(border, ui, dark),
+        focus: _color(brand, primary),
+      ),
+      box-shadow: (
+        default: none,
+        hover: none,
+        active: 0 1px 2px rgba(black, 0.2) inset,
+        focus: none,
+      ),
+      text: (
+        default: _color(text),
+        hover: _color(text),
+        active: _color(text),
+        focus: _color(text),
+      ),
+    ),
+  ),
+), default);
+
+// Primary
+@include _color((
+  button: (
+    primary: (
+      background: (
+        default: _color(brand, primary),
+        hover: darken(_color(brand, primary), 4),
+        active: darken(_color(brand, primary), 8)
+      ),
+      border: (
+        default: darken(_color(brand, primary), 8),
+        hover: darken(_color(brand, primary), 8),
+        active: darken(_color(brand, primary), 8),
+        focus: darken(_color(brand, primary), 8),
+      ),
+      box-shadow: (
+        focus: 0 0 0 1px rgba(white, 0.4) inset,
+      ),
+      text: (
+        default: white,
+        hover: white,
+        active: white,
+        focus: white,
+      ),
+    ),
+  ),
+), default);
+
+// Link
+@include _color((
+  button: (
+    link: (
+      background: (
+        default: transparent,
+        hover: transparent,
+        active: transparent,
+        focus: transparent,
+      ),
+      border: (
+        default: transparent,
+        hover: transparent,
+        active: transparent,
+        focus: transparent,
+      ),
+      box-shadow: (
+        default: none,
+        hover: none,
+        active: none,
+        focus: none,
+      ),
+      text: (
+        default: _color(brand, primary),
+        hover: _color(brand, primary),
+        active: _color(brand, primary),
+        focus: _color(brand, primary),
+      ),
+    ),
+  ),
+), default);

--- a/scss/pack/seed-button/mixins/__set-button-prop.scss
+++ b/scss/pack/seed-button/mixins/__set-button-prop.scss
@@ -1,5 +1,7 @@
 // Mixin :: __set-button-prop
 
+@import "pack/seed-dash/_index";
+
 // Private mixin for generate-button-styles
 @mixin __set-button-prop($prop: false, $config: false, $state: default, $override: false) {
   @if not $prop {

--- a/scss/pack/seed-button/mixins/__set-button-text-color.scss
+++ b/scss/pack/seed-button/mixins/__set-button-text-color.scss
@@ -1,5 +1,7 @@
 // Mixin :: __set-button-text-color
 
+@import "pack/seed-dash/_index";
+
 // Private mixin for generate-button-styles
 @mixin __set-button-text-color($config, $state, $override: false) {
   $color: _get($config, text);

--- a/test/components/base.js
+++ b/test/components/base.js
@@ -43,7 +43,7 @@ describe('base', () => {
     const $o = styles.find('.c-button');
 
     it('should have a background', () => {
-      expect($o.prop('background')).to.equal('rgb(255, 255, 255)');
+      expect($o.prop('background')).to.equal('white');
     });
 
     it('should have border styles', () => {

--- a/test/components/modifiers/styles.link.js
+++ b/test/components/modifiers/styles.link.js
@@ -1,8 +1,16 @@
 const styles = barista({
-  content: `@import "./_index"`,
+  content: `
+    @import "./_index";
+
+    .text {
+      color: _color(text);
+    }
+  `,
 });
 
 describe('styles: link', () => {
+  const text = styles.rule('.text');
+
   it('should be defined', () => {
     expect(styles.rule('.c-button--link').exists()).to.be.true;
   });
@@ -36,6 +44,7 @@ describe('styles: link', () => {
       expect(s.exists()).to.be.true;
       expect(s.prop('background-color')).to.equal('transparent');
       expect(s.prop('border-color')).to.equal('transparent');
+      expect(s.prop('color')).to.not.equal(text.prop('color'));
     });
 
     it('should have a :active state', () => {
@@ -44,6 +53,7 @@ describe('styles: link', () => {
       expect(s.exists()).to.be.true;
       expect(s.prop('background-color')).to.equal('transparent');
       expect(s.prop('border-color')).to.equal('transparent');
+      expect(s.prop('color')).to.not.equal(text.prop('color'));
     });
 
     it('should have a :focus state', () => {
@@ -52,6 +62,7 @@ describe('styles: link', () => {
       expect(s.exists()).to.be.true;
       expect(s.prop('text-decoration')).to.equal('underline');
       expect(s.prop('border-color')).to.equal('transparent');
+      expect(s.prop('color')).to.not.equal(text.prop('color'));
     });
   });
 });

--- a/test/configs/color.js
+++ b/test/configs/color.js
@@ -1,0 +1,31 @@
+describe('color', () => {
+  it('should modify base styles with _color() change', () => {
+    const color = 'red';
+    const content = `
+      @import "pack/seed-color-scheme/_index";
+
+      @include _color((
+        button: (
+          default: (
+            background: (
+              default: ${color},
+            ),
+            border: (
+              default: ${color},
+            ),
+            text: (
+              default: ${color},
+            ),
+          ),
+        ),
+      ));
+      @import "./_index";
+    `;
+    const styles = barista({ content });
+    const o = styles.rule('.c-button');
+
+    expect(o.prop('background-color')).to.equal(color);
+    expect(o.prop('border-color')).to.equal(color);
+    expect(o.prop('color')).to.equal(color);
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-describe('index', function() {
+describe('index', () => {
   const css = `
     @import "./_index";
     @import "./_index";
@@ -8,7 +8,7 @@ describe('index', function() {
   `;
   const styles = barista({ content: css });
 
-  it('should only be compiled once', function() {
+  it('should only be compiled once', () => {
     expect(styles.rule('.c-button').selectors).to.have.lengthOf(1);
     expect(styles.rule('.c-button--primary').selectors).to.have.lengthOf(1);
     expect(styles.rule('.c-button--link').selectors).to.have.lengthOf(1);


### PR DESCRIPTION
## Update

### Update button colors with `seed-color-scheme` config 🖌 

This allows for better flexibility in adjusting button colors. The user can now leverage the `_color()` mixin/function, without having to manually import config files + doing `_deep-extend()` (which was the previous work-around).

The color defines are flagged with `default`, and live under `/configs/_color.scss`.

#### Examples:

Let's say, we want to override the default buttons base background, border, and text colors. You can now do this:

```scss
// Import the color scheme dependency
@import "pack/seed-color-scheme/_index";

// Use the _color() mixin, and pass in whatever key/values you wish to set
@include _color((
  button: (
    default: (
      background: (
        default: red,
      ),
      border: (
        default: red,
      ),
      text: (
        default: red,
      ),
    ),
  ),
));

// Add seed-button
@import "pack/seed-button/_index";
```
 
This update would have made [this](https://github.com/helpscout/seed-button/issues/12) **much easier** to accomplish.

### Dependency updates

#### Added

* [`seed-color-scheme#v0.3.0`](https://github.com/helpscout/seed-color-scheme/releases/tag/v0.3.0)

#### Removed

* [`seed-states`](https://github.com/helpscout/seed-states)